### PR TITLE
start one awe client in a docker container

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -60,7 +60,7 @@ elif [ "$MYSERVICES" = "aweworker" ] ; then
   sed -i 's/\/kb\/runtime\/sbin\/daemonize.*PID_FILE//' /kb/deployment/services/awe_service/start_*
   . /kb/deployment/user-env.sh 
   cd /kb/deployment/services/awe_service
-  ./start_aweworker $CGROUP
+  ./start_aweclient $CGROUP
 elif [ "$MYSERVICES" = "narrative_job_service" ] ; then
   USER=$(grep service_auth_name $CONFIG|sed 's/service_auth_name=//')
   PASS=$(grep service_auth_pass $CONFIG|sed 's/service_auth_pass=//')

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -60,7 +60,7 @@ elif [ "$MYSERVICES" = "aweworker" ] ; then
   sed -i 's/\/kb\/runtime\/sbin\/daemonize.*PID_FILE//' /kb/deployment/services/awe_service/start_*
   . /kb/deployment/user-env.sh 
   cd /kb/deployment/services/awe_service
-  ./start_service
+  ./start_aweworker $CGROUP
 elif [ "$MYSERVICES" = "narrative_job_service" ] ; then
   USER=$(grep service_auth_name $CONFIG|sed 's/service_auth_name=//')
   PASS=$(grep service_auth_pass $CONFIG|sed 's/service_auth_pass=//')


### PR DESCRIPTION
Call start_aweclient script directly from entrypoint.sh, instead of calling start_service wrapper (so that we are able to start only one worker in a Docker container).